### PR TITLE
Improve path length by more than 50 %

### DIFF
--- a/lib/Triangle.py
+++ b/lib/Triangle.py
@@ -24,7 +24,7 @@ def try_ordered_edge(a,p,q,reversible):
         p,q = q,p
     
     m = a.size()
-    a.add_edge(p,q,{'order':m,'reversible':reversible,'fields':[]})
+    a.add_edge(p,q,{'order':m,'reversible':reversible,'fields':[],'depends':[]})
 
     try:
         a.edgeStack.append( (p,q) )
@@ -195,9 +195,18 @@ class Triangle:
         p,q = edges[lastInd]
 
         self.a.edge[p][q]['fields'].append(self.verts)
+        # the last edge depends on the other two
+        del edges[lastInd]
+        self.a.edge[p][q]['depends'].extend(edges)
 
         for child in self.children:
             child.markEdgesWithFields()
+
+        # all edges starting from inside this triangle have to be completed before it
+        for c in self.contents:
+            self.a.edge[p][q]['depends'].append(c)
+
+        #print("edge %d-%d depends on: %s" % (p, q, self.a.edge[p][q]['depends']))
 
     def edgesByDepth(self,depth):
         # Return list of edges of triangles at given depth

--- a/lib/Triangle.py
+++ b/lib/Triangle.py
@@ -169,7 +169,12 @@ class Triangle:
         return np.all(np.sum(self.orths*(pt-self.pts),1) < 0)
 
     # Attach to each edge a list of fields that it completes
-    def markEdgesWithFields(self):
+    def markEdgesWithFields(self, clean=False):
+        if clean:
+            for p,q in self.a.edges_iter():
+                self.a.edge[p][q]['fields'] = []
+                self.a.edge[p][q]['depends'] = []
+
         edges = [(0,0)]*3
         for i in range(3):
             p = self.verts[i-1]
@@ -195,9 +200,17 @@ class Triangle:
         p,q = edges[lastInd]
 
         self.a.edge[p][q]['fields'].append(self.verts)
-        # the last edge depends on the other two
-        del edges[lastInd]
-        self.a.edge[p][q]['depends'].extend(edges)
+        if not self.exterior:
+            # the last edge depends on the other two
+            del edges[lastInd]
+            self.a.edge[p][q]['depends'].extend(edges)
+        else:
+            # in an exterior triangle that has children, only the edge
+            # on the opposite side of the "final" vertex is a dependency;
+            # childless exterior triangles can be built in any order
+            if len(self.children) > 0:
+                self.a.edge[p][q]['depends'].append(edges[0])
+
 
         for child in self.children:
             child.markEdgesWithFields()

--- a/makePlan.py
+++ b/makePlan.py
@@ -257,6 +257,15 @@ def main():
 
         agentOrder.improveEdgeOrder(a)
 
+        # Fix the stars of edges that can be done early
+        try:
+            n = 0
+            for t in a.triangulation:
+                t.markEdgesWithFields(clean = n==0)
+                n += 1
+        except AttributeError:
+            print "Error: problem with bestgraph... no triangulation...?"
+
         with open(output_directory+output_file,'w') as fout:
             pickle.dump(a,fout)
     else:


### PR DESCRIPTION
Here is a suggestion to improve the output of maxfield to be much shorter. For example, for the courtsquare.portals example input, for one agent, the suggested route is:

```
Total time estimate: 17 minutes
Agent distance:   1008 m
Agent experience: 43140 AP
```

compared with the

```
Total time estimate: 28 minutes
Agent distance:   2294 m
Agent experience: 43140 AP
```

of the unmodified code.

In my tests the length improvement of the route for one agent has been typically more than 50 %, but naturally it depends on the randomization. For more agents the benefit may be smaller, but I don't have any figures for that.

There probably are still easy improvements to be made to the algorithm. The most common error result for a bad modification is two (or more) triangles forming on the same side of a link at the same time (getting a field and AP only for the largest). So, anybody experimenting with the code should keep an eye open for those. I have run the code through automatic tests some hundreds of times, and this version so far has not failed.

(originally I submitted a pull request to the "upstream" at https://github.com/jpeterbaker/maxfield/pull/34, but so far received no response there; perhaps the website users would benefit of these changes)
