### PR TITLE
fix try_reduce_out_degree: don't reverse irreversible edges

### DIFF
--- a/lib/Triangle.py
+++ b/lib/Triangle.py
@@ -33,9 +33,10 @@ def try_reduce_out_degree(a,p):
     toremove = []
     for q in a.edge[p]:
         if ((a.node[q]['sbla'] and a.out_degree(q) < 40) or (a.out_degree(q) < 8)):
-            a.add_edge(q,p)
-            a.edge[q][p] = a.edge[p][q]
-            toremove.append(q)
+            if a.edge[p][q]['reversible']:
+                a.add_edge(q,p)
+                a.edge[q][p] = a.edge[p][q]
+                toremove.append(q)
 
     for q in toremove:
         a.remove_edge(p,q)


### PR DESCRIPTION
`try_reduce_out_degree` is eager to reverse edges without any regards to whether an edge under consideration is actually reversible. The occasional result of this is that a link in the generated plan cannot be made, because the source portal is inside a field. An example of such a bad plan is shown below (the plan suggests four successive bad links).
![screenshot - 2016-03-06 15-24-11](https://cloud.githubusercontent.com/assets/7499643/13554405/95dd4432-e3af-11e5-871a-ee818ada76ea.png)

This bug comes from upstream.
