### PR TITLE
prune redundant states in branch_bound

### DIFF
--- a/lib/Triangle.py
+++ b/lib/Triangle.py
@@ -74,6 +74,9 @@ def try_ordered_edge(a,p,q,reversible,allow_suboptimal):
         # print 'adding',p,q
         # print a.edgeStack
 
+
+triangleContentCache = {}
+
 class Triangle:
     def __init__(self,verts,a,exterior=False,allow_suboptimal=_ALLOW_SUBOPTIMAL):
         '''
@@ -108,11 +111,20 @@ class Triangle:
     def findContents(self,candidates=None):
         if candidates == None:
             candidates = xrange(self.a.order())
-        for p in candidates:
-            if p in self.verts:
-                continue
-            if geometry.sphereTriContains(self.pts,self.a.node[p]['xyz']):
-                self.contents.append(p)
+
+        triangleKey = sum([1 << p for p in self.verts])
+
+        if triangleKey in triangleContentCache:
+            self.contents.extend(triangleContentCache[triangleKey])
+
+        else:
+            for p in candidates:
+                if p in self.verts:
+                    continue
+                if geometry.sphereTriContains(self.pts,self.a.node[p]['xyz']):
+                    self.contents.append(p)
+            triangleContentCache[triangleKey] = self.contents
+
 
     def randSplit(self):
         if len(self.contents) == 0:

--- a/lib/branch_bound.py
+++ b/lib/branch_bound.py
@@ -59,14 +59,38 @@ def branch_bound(root,lo,hi,callback=None):
     states = [root]
     finals = [] # Terminating states
 
+    # returns true, if an equivalent state of agents has already been
+    # added with a smaller time value
+    def isRedundant(candidate, cache):
+        # creates a bitmap where a '1' in position 'x' (i.e., 1 << x)
+        # means that an agent's last action was to complete
+        # the link number 'x' of the plan
+        key = sum([1 << i for i in candidate.lastat[-1] if i != None])
+
+        val = state.time[-1]
+        try:
+            prev = cache[key]
+            if val < prev:
+                cache[key] = val
+                return False
+            else:
+                return True
+        except KeyError:
+            cache[key] = val
+            return False
+
+
     while len(states) > 0:
         callback()
 
         # The branches of the states
         branches = []
+        bestvals = {}
+
         for state in states:
             try:
-                branches.extend(state.split(splitSize))
+                candidates = state.split(splitSize)
+                branches.extend([c for c in candidates if not isRedundant(c, bestvals)])
                 # print len(branches),'branches'
             except CantSplit:
                 finals.append(state)


### PR DESCRIPTION
There is no difference whether links are
made by agents

0, 1, 2, ...
0, 2, 1, ...
0, 1, 3, ...
....

Thus quite a lot of the states generated during the branching
phase can simply be pruned away. This improves the running time of the program, when the number of agents is larger than 1.
