### PR TITLE
Optimize walking distance

### DIFF
--- a/lib/Triangle.py
+++ b/lib/Triangle.py
@@ -65,7 +65,7 @@ def try_ordered_edge(a,p,q,reversible,allow_suboptimal):
         p,q = q,p
     
     m = a.size()
-    a.add_edge(p,q,{'order':m,'reversible':reversible,'fields':[]})
+    a.add_edge(p,q,{'order':m,'reversible':reversible,'fields':[],'depends':[]})
 
     try:
         a.edgeStack.append( (p,q) )
@@ -257,9 +257,18 @@ class Triangle:
         p,q = edges[lastInd]
 
         self.a.edge[p][q]['fields'].append(self.verts)
+        # the last edge depends on the other two
+        del edges[lastInd]
+        self.a.edge[p][q]['depends'].extend(edges)
 
         for child in self.children:
             child.markEdgesWithFields()
+
+        # all edges starting from inside this triangle have to be completed before it
+        for c in self.contents:
+            self.a.edge[p][q]['depends'].append(c)
+
+        #print("edge %d-%d depends on: %s" % (p, q, self.a.edge[p][q]['depends']))
 
     def edgesByDepth(self,depth):
         # Return list of edges of triangles at given depth

--- a/lib/agentOrder.py
+++ b/lib/agentOrder.py
@@ -292,6 +292,114 @@ def improveEdgeOrder(a):
         a.edge[p][q]['order'] = i
         # print
 
+
+def improveEdgeOrderMore(a):
+    '''
+    A greedy algorithm to reduce the path length.
+    Moves edges earlier or later, if they can be moved (dependencies are
+    done in the proper order) and the move reduces the total length of the
+    path.
+    The algorithm tries to move 1 to 5 edges at the same time as a block
+    to improve upon certain types of local optima.
+    '''
+
+    m = a.size()
+    # If link i is e then orderedEdges[i]=e
+    orderedEdges = [-1]*m
+
+    geo = np.array([ a.node[i]['geo'] for i in xrange(a.order())])
+    d = geometry.sphereDist(geo,geo)
+
+    def pathLength(d, edges):
+        return sum([d[edges[i][0]][edges[i+1][0]] for i in xrange(len(edges)-1)])
+
+    def dependsOn(subjects, objects):
+        '''
+        Returns True, if an edge inside 'objects' should be made before
+        one (or more) of the edges inside 'subjects'
+        '''
+        for p,q in subjects:
+            depends = a.edge[p][q]['depends']
+            for u,v in objects:
+                if depends.count((u,v,)) + depends.count(u) > 0:
+                    return True
+
+        return False
+
+
+    def possiblePlaces(j, block):
+        '''
+        A generator returning the possible places of the given
+        block of edges within the complete edge sequence.
+        The current position (j) is not returned.
+        '''
+        pos = j
+        # smaller index means made earlier
+        while pos > 0 and not dependsOn(block, [orderedEdges[pos-1]]):
+            pos -= 1
+            yield pos
+
+        pos = j
+        bsize = len(block)
+        n = len(orderedEdges) - bsize + 1
+        # bigger index means made later
+        while pos < n-1 and not dependsOn([orderedEdges[pos+bsize]], block):
+            pos += 1
+            yield pos
+
+
+    for p,q in a.edges_iter():
+        orderedEdges[a.edge[p][q]['order']] = (p,q)
+
+    origLength = pathLength(d, orderedEdges)
+    bestLength = origLength
+
+    cont = True
+    while cont:
+        cont = False
+        for j in xrange(m):
+            best = j
+            bestPath = orderedEdges
+
+            # max block size is 5 (6-1); chosen arbitrarily
+            for block in xrange(1, 6):
+                moving = orderedEdges[j:j+block]
+                for possible in possiblePlaces(j, moving):
+                    if possible < j:
+                        # Move the links to be at an earlier index
+                        path = orderedEdges[   :possible] +\
+                                    moving +\
+                                    orderedEdges[possible  :j] +\
+                                    orderedEdges[j+block: ]
+                    else:
+                        # Move to a later position
+                        path = orderedEdges[   :j] +\
+                                    orderedEdges[j+block: possible+block] +\
+                                    moving +\
+                                    orderedEdges[possible+block  :]
+
+                    length = pathLength(d,path)
+
+                    if length < bestLength:
+                        #print("Improved by %f meters in index %d (from %d, block %d)" % (bestLength-length, possible, best, block))
+                        best = possible
+                        bestLength = length
+                        bestPath = path
+
+            if best != j:
+                #print("New order (%d -> %d): %s" % (j, best, bestPath))
+                orderedEdges = bestPath
+                cont = True
+
+    length = pathLength(d, orderedEdges)
+    print
+    #print("Length reduction: original = %d, improved = %d, change = %d meters" % (origLength, length, length-origLength))
+
+    for i in xrange(m):
+        p,q = orderedEdges[i]
+        a.edge[p][q]['order'] = i
+
+
 if __name__=='__main__':
     order = [0,5,5,5,2,2,1,0]
     # order = [5]*5

--- a/makePlan.py
+++ b/makePlan.py
@@ -300,6 +300,15 @@ def main(args):
             best_plan = b
             best_PP = copy.deepcopy(PP)
             best_time = totalTime
+
+
+    b = best_plan
+    agentOrder.improveEdgeOrderMore(b)
+    best_PP = PlanPrinterMap.PlanPrinter(b,output_directory,nagents,useGoogle=useGoogle,
+                                    api_key=api_key,color=color)
+    best_time = b.walktime+b.linktime+b.commtime
+
+
     if not args.quiet:
         tdiff = time.time() - start_time
         hrs = int(tdiff/3600.)

--- a/makePlan.py
+++ b/makePlan.py
@@ -304,6 +304,18 @@ def main(args):
 
     b = best_plan
     agentOrder.improveEdgeOrderMore(b)
+
+    # Re-run to fix the animations and stars of edges that can be done early
+    # (improveEdgeOrderMore may have modified the completion order)
+    try:
+        first = True
+        for t in b.triangulation:
+            t.markEdgesWithFields(clean = first)
+            first = False
+    except AttributeError:
+        print "Error: problem with bestgraph... no triangulation...?"
+
+
     best_PP = PlanPrinterMap.PlanPrinter(b,output_directory,nagents,useGoogle=useGoogle,
                                     api_key=api_key,color=color)
     best_time = b.walktime+b.linktime+b.commtime


### PR DESCRIPTION
This is a variation of the pull request #2.

Since `improveEdgeOrder` is called several times in a loop, I put the new code in a new function, `improveEdgeOrderMore`, that is only called once on the final plan. This doesn't affect the running time of the program as much, but also may give slightly poorer results (the triangulation chosen with the `improveEdgeOrder` metric may not be the one giving the best result with `improveEdgeOrderMore`).

This still seems to make the path much shorter no matter what the triangulation actually is, so no harm there (perhaps the `attempts` loop could optimize on something else besides the path length again?).
