### PR TITLE
Fix computation of triangleKey for higher number of portals (>64)

### DIFF
--- a/lib/Triangle.py
+++ b/lib/Triangle.py
@@ -112,7 +112,7 @@ class Triangle:
         if candidates == None:
             candidates = xrange(self.a.order())
 
-        triangleKey = sum([1 << p for p in self.verts])
+        triangleKey = sum([1 << int(p) for p in self.verts])
 
         if triangleKey in triangleContentCache:
             self.contents.extend(triangleContentCache[triangleKey])


### PR DESCRIPTION
Elements of verts list in Triangle class has types either int or numpy.int64.
For v of type int the type of (1 << v) is automatically promoted to long for large v.
For v of type numpy.int64 (1 << v) is kept as numpy.int64, so the triangleKey gets invalid, truncated value.
Fix it by casting types of v to int, during the computation of the triangleKey.