### PR TITLE
Improve performance of agentOrder.improveEdgeOrderMore

### DIFF
--- a/lib/agentOrder.py
+++ b/lib/agentOrder.py
@@ -382,7 +382,7 @@ def improveEdgeOrderMore(a):
                     removedEdgesLengthBase += d[orderedEdges[j+block-1][0], orderedEdges[j+block][0]]
                 if j > 0 and j+block<m:
                     addedEdgesLengthBase += d[orderedEdges[j-1][0], orderedEdges[j+block][0]]
-                for possible in filter and possiblePlaces(j, moving):
+                for possible in possiblePlaces(j, moving):
                     addedEdgesLength = addedEdgesLengthBase
                     removedEdgesLength = removedEdgesLengthBase
                     if possible > 0:


### PR DESCRIPTION
Do not recompute the length of the path in each iteration of improveEdgeOrderMore.
Instead, in each iteration compute only lengths of (at most) 3 removed edges,
 and (at most) 3 added edges and use it to update the original path length.
This brings down complexity of the algorithm significantly.
For my test of 150 portals it brings time down from over 1 minute to 3 seconds.
It's now feasible to run the improveEdgeOrderMore on every candidate edge order,
and choose the "best" edge order more accurately.