### PR TITLE
added inbound-only portals

### DIFF
--- a/maxfield/field.py
+++ b/maxfield/field.py
@@ -56,10 +56,11 @@ def can_add_outbound(graph, portal):
       can_add :: boolean
         True if we can add another outgoing link from portal
     """
-    max_out = _OUTGOING_LIMIT
     if graph.nodes[portal]['sbul']:
-        max_out = _OUTGOING_LIMIT_SBUL
-    return graph.out_degree(portal) < max_out
+        return graph.out_degree(portal) < _OUTGOING_LIMIT_SBUL
+    if graph.nodes[portal]['inbound']:
+        return graph.out_degree(portal) < 0
+    return graph.out_degree(portal) < _OUTGOING_LIMIT
 
 
 def add_link(graph, portal1, portal2, reversible=False):

--- a/maxfield/plan.py
+++ b/maxfield/plan.py
@@ -106,6 +106,7 @@ class Plan:
         for i, portal in enumerate(self.portals):
             self.graph.add_node(i)
             self.graph.nodes[i]['sbul'] = portal['sbul']
+            self.graph.nodes[i]['inbound'] = portal['inbound']
             self.graph.nodes[i]['keys'] = portal['keys']
 
     def optimize(self, num_field_iterations=100, num_cpus=1):


### PR DESCRIPTION
Decided to test my idea from #33 , and it works as expected :)

PR adds support for `inbound` flag, which sets the maximum outbound links for a portal to 0, effectively forcing the algorithm to create only inbound links from other portals.

The plan supports only one inbound portal, otherwise the calculation takes forever to complete (if it completes at all).

The flag is exclusive with SBUL, raising the necessary error.