### PR TITLE
Bump protobuf from 3.19.4 to 4.21.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='Trey V. Wenger',
     author_email='tvwenger@gmail.com',
     packages=['maxfield'],
-    install_requires=['numpy', 'networkx', 'scipy', 'ortools', 'protobuf==3.19.4',
+    install_requires=['numpy', 'networkx', 'scipy', 'ortools', 'protobuf==4.21.5',
                       'matplotlib', 'imageio', 'pygifsicle'],
     scripts=['bin/maxfield-plan'],
 )


### PR DESCRIPTION
Solves this crash which happens when cloning and ruining the install script on pop-os (ubuntu based)

![image](https://user-images.githubusercontent.com/9498498/210064764-9e719e28-bccf-424e-8009-99eaf9d43f43.png)
